### PR TITLE
Allow configuration of run_id, drop xhprof_lib dependency

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -3,10 +3,10 @@
 return [
     'enabled' => true,
     'global_middleware' => true,
-    'path' => '/opt/xhprof',
     'output_dir' => null,
     'name' => 'xhprof',
     'freq' => 1 / 1000,
     'extension_name' => 'xhprof',
     'provider' => \Bavix\XHProf\Providers\XHProfProvider::class,
+    'run_id' => uniqid(),
 ];

--- a/src/Providers/TidewaysProvider.php
+++ b/src/Providers/TidewaysProvider.php
@@ -12,9 +12,6 @@ class TidewaysProvider implements ProviderInterface
      */
     public function enable()
     {
-        $path = config('xhprof.path');
-        include_once $path . '/xhprof_lib/utils/xhprof_lib.php';
-        include_once $path . '/xhprof_lib/utils/xhprof_runs.php';
         tideways_xhprof_enable(config('xhprof.flags', 0));
     }
 
@@ -24,8 +21,13 @@ class TidewaysProvider implements ProviderInterface
     public function disable()
     {
         $data = tideways_xhprof_disable();
-        $runs = new XHProfRuns_Default(config('xhprof.output_dir', null));
-        $runs->save_run($data, config('xhprof.name'));
+
+        $run_id = config('xhprof.run_id', null) ?? uniqid();
+
+        file_put_contents(
+                config('xhprof.output_dir', '/tmp') . '/' . $run_id . '.' . config('xhprof.name') . '.xhprof',
+                serialize($data)
+                );
     }
 
 }

--- a/src/Providers/XHProfProvider.php
+++ b/src/Providers/XHProfProvider.php
@@ -14,9 +14,6 @@ class XHProfProvider implements ProviderInterface
      */
     public function enable()
     {
-        $path = config('xhprof.path');
-        include_once $path . '/xhprof_lib/utils/xhprof_lib.php';
-        include_once $path . '/xhprof_lib/utils/xhprof_runs.php';
         xhprof_enable(config('xhprof.flags', 0));
     }
 
@@ -26,8 +23,13 @@ class XHProfProvider implements ProviderInterface
     public function disable()
     {
         $data = xhprof_disable();
-        $runs = new XHProfRuns_Default(config('xhprof.output_dir', null));
-        $runs->save_run($data, config('xhprof.name'));
+
+        $run_id = config('xhprof.run_id', null) ?? uniqid();
+
+        file_put_contents(
+                config('xhprof.output_dir', '/tmp') . '/' . $run_id . '.' . config('xhprof.name') . '.xhprof',
+                serialize($data)
+                );
     }
 
 }


### PR DESCRIPTION
* Generate run_id() in the config, so that another part of code can put a link/header in the page for easily accessing the profiled data.
* Drop the dependency on the xhprof_lib files, as the needed code is just a `file_put_contents` of the serialized data.